### PR TITLE
fix strftime format string

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -14,7 +14,7 @@
     {% for entry in entries %}
     <div class="post">
       <span class="title"><a href="{{ entry.url }}">{{ entry.title }}</a></span>
-      <time class="created" datetime="{{ entry.created.strftime('%Y-%m-%d') }}">{{ entry.created.strftime('%B %-d, %Y')
+      <time class="created" datetime="{{ entry.created.strftime('%Y-%m-%d') }}">{{ entry.created.strftime('%B %e, %Y')
         }}</time>
     </div>
     {% endfor %}

--- a/templates/meta.html
+++ b/templates/meta.html
@@ -1,7 +1,7 @@
 {% if entry.created %}
 <div class="meta">
   {% if entry.created %}
-  <time class="created" datetime="{{ entry.created.strftime('%Y-%m-%d') }}">{{ entry.created.strftime('%B %-d, %Y')
+  <time class="created" datetime="{{ entry.created.strftime('%Y-%m-%d') }}">{{ entry.created.strftime('%B %e, %Y')
     }}</time>
   {% endif %}
 </div>


### PR DESCRIPTION
Replace `%-d` with `%e` to avoid the zero-padding for OS independence.

`%-d` on UNIX needs to be replaced by `%#d` on Windows, otherwise "ValueError: Invalid format string" will be thrown. Replacing with `%e` will avoid OS dependencies while having the same output.

Tested on Windows 11 and Ubuntu 20.04 (x86_64).

Reference: <https://man7.org/linux/man-pages/man3/strftime.3.html>